### PR TITLE
Coloured potatoes and eggplants

### DIFF
--- a/CULLinary2/Assets/Models/Eggplant/eggplantEnemyNew.prefab
+++ b/CULLinary2/Assets/Models/Eggplant/eggplantEnemyNew.prefab
@@ -155,6 +155,7 @@ GameObject:
   - component: {fileID: 2956305753384301904}
   - component: {fileID: -1025067568391436741}
   - component: {fileID: 6106420228487427490}
+  - component: {fileID: 7510566642343784119}
   m_Layer: 0
   m_Name: eggplantEnemyNew
   m_TagString: Untagged
@@ -367,6 +368,7 @@ MonoBehaviour:
   distanceTriggered: 16
   stopChase: 20
   lootDropped: {fileID: 1575108546322888687, guid: 94eed080e57614e9d84fdd0d2185bd37, type: 3}
+  additionalSpawningNumbers: 0
   spawner: {fileID: 0}
   hpBarPrefab: {fileID: 1085209639500972291, guid: 4614e0511cb49b14ebf0c58217d9d222, type: 3}
   damageCounterPrefab: {fileID: 1085209639500972291, guid: 24f41dda89c7bd648bd2796ac669721e, type: 3}
@@ -383,6 +385,25 @@ MonoBehaviour:
   alertSound: {fileID: 8300000, guid: f887160af86d3844b80236fc380ba79d, type: 3}
   attackSound: {fileID: 8300000, guid: b27e425790eebc643bf37744875e751c, type: 3}
   primaryEnemyAttack: {fileID: 3026806480666303626}
+  onDamageColor: {r: 1, g: 1, b: 1, a: 1}
+  texturesForFlash: []
+--- !u!114 &7510566642343784119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 807139516458123811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b40dd2c1d5ce28e4ca0cbfe021def656, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  monsterRenderer: {fileID: 7488626821991979531}
+  tintColours:
+  - {r: 0.79607844, g: 0.5019608, b: 0.54901963, a: 0}
+  - {r: 0.4745098, g: 1, b: 0.38431373, a: 0}
+  - {r: 1, g: 0.8, b: 0.5372549, a: 0}
 --- !u!1 &1300043781058513626
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Models/Potato/PotatoEnemyNew.prefab
+++ b/CULLinary2/Assets/Models/Potato/PotatoEnemyNew.prefab
@@ -693,6 +693,7 @@ GameObject:
   - component: {fileID: 5806749913654623873}
   - component: {fileID: -2664355154039104880}
   - component: {fileID: 3032895445469368953}
+  - component: {fileID: 5689706197273364680}
   m_Layer: 0
   m_Name: PotatoEnemyNew
   m_TagString: Untagged
@@ -923,3 +924,22 @@ MonoBehaviour:
   alertSound: {fileID: 8300000, guid: f887160af86d3844b80236fc380ba79d, type: 3}
   attackSound: {fileID: 8300000, guid: 3e970a0a6aa62c24fa568ad102d5cd59, type: 3}
   primaryEnemyAttack: {fileID: 4968055034188887457}
+  onDamageColor: {r: 1, g: 1, b: 1, a: 1}
+  texturesForFlash: []
+--- !u!114 &5689706197273364680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9062019569830792200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b40dd2c1d5ce28e4ca0cbfe021def656, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  monsterRenderer: {fileID: 7325621177007739663}
+  tintColours:
+  - {r: 1, g: 0.9843137, b: 0.5254902, a: 0}
+  - {r: 1, g: 0.73333335, b: 0.8666667, a: 0}
+  - {r: 0.48235294, g: 0.39215687, b: 0.6039216, a: 0}

--- a/CULLinary2/Assets/Scripts/Dungeon/Minimap.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Minimap.cs
@@ -140,7 +140,7 @@ public class Minimap : MonoBehaviour
             }
             foreach ((Transform fire, Transform icon) in campfireIcons)
             {
-                SetIconPos(fire, icon, false);
+                SetIconPos(fire, icon, true);
             }
             // Update player icon
             SetPlayerIconPos();


### PR DESCRIPTION
Add the varying colour script to all monsters, based on natural colours of those vegetables
Also hide campfire icons that are outside of the minimap