### PR TITLE
Many big bug fixes and tweaks

### DIFF
--- a/CULLinary2/Assets/Animations/Bob.anim
+++ b/CULLinary2/Assets/Animations/Bob.anim
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bob
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 38
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2
+        value: 26
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 4
+        value: 38
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 538195251
+      script: {fileID: 0}
+      typeID: 224
+      customType: 28
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 4
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 38
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2
+        value: 26
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 4
+        value: 38
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CULLinary2/Assets/Animations/Bob.anim.meta
+++ b/CULLinary2/Assets/Animations/Bob.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3826c69bf2a34324ead2571d0524409e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Animations/BobController.controller
+++ b/CULLinary2/Assets/Animations/BobController.controller
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-6400109689925034301
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bob
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 3826c69bf2a34324ead2571d0524409e, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-1431892966464684688
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6400109689925034301}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BobController
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 1983944682611797164}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1107 &1983944682611797164
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -6400109689925034301}
+    m_Position: {x: 424, y: 114, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: -1431892966464684688}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -6400109689925034301}

--- a/CULLinary2/Assets/Animations/BobController.controller.meta
+++ b/CULLinary2/Assets/Animations/BobController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15e718841f2880143b8cb5482f5efc9e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Animations/BobMore.anim
+++ b/CULLinary2/Assets/Animations/BobMore.anim
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BobMore
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 65
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.8333333
+        value: 55
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 65
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 538195251
+      script: {fileID: 0}
+      typeID: 224
+      customType: 28
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.6666666
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 65
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.8333333
+        value: 55
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 65
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_AnchoredPosition.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CULLinary2/Assets/Animations/BobMore.anim.meta
+++ b/CULLinary2/Assets/Animations/BobMore.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbd38c3036f8ece4ab0aafdd529352d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Animations/BobMoreController.controller
+++ b/CULLinary2/Assets/Animations/BobMoreController.controller
@@ -1,0 +1,95 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-7722032846047293452
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8894002321865437291}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1107 &-3648862179894247337
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 8894002321865437291}
+    m_Position: {x: 418.3969, y: 84.12213, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: -7722032846047293452}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 8894002321865437291}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BobMoreController
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3648862179894247337}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &8894002321865437291
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BobMore
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cbd38c3036f8ece4ab0aafdd529352d8, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/CULLinary2/Assets/Animations/BobMoreController.controller.meta
+++ b/CULLinary2/Assets/Animations/BobMoreController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 495df310d3373964ebd27936094ac18e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Animations/BuffBgFlash.anim
+++ b/CULLinary2/Assets/Animations/BuffBgFlash.anim
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BuffBgFlash
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.68627
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 0.6862745
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 304273561
+      script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+      typeID: 114
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.68627
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 0.6862745
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: 
+    classID: 114
+    script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CULLinary2/Assets/Animations/BuffBgFlash.anim.meta
+++ b/CULLinary2/Assets/Animations/BuffBgFlash.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe8179227aba9a44ebe98b524f7af260
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Animations/BuffBgFlashController.controller
+++ b/CULLinary2/Assets/Animations/BuffBgFlashController.controller
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-1373369489528343567
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 311660382174676829}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BuffBgFlashController
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: flashStarted
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 8830503656818083195}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1101 &311660382174676829
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: flashStarted
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4724252006798806022}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &4724252006798806022
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Flashing
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: fe8179227aba9a44ebe98b524f7af260, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &8830503656818083195
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -1373369489528343567}
+    m_Position: {x: 330, y: 60, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4724252006798806022}
+    m_Position: {x: 450, y: 150, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -1373369489528343567}

--- a/CULLinary2/Assets/Animations/BuffBgFlashController.controller.meta
+++ b/CULLinary2/Assets/Animations/BuffBgFlashController.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24a4e3b818b1615408d06e204033e986
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Prefabs/Archive/Prefabs/DungeonEnemies/hpBar.prefab
+++ b/CULLinary2/Assets/Prefabs/Archive/Prefabs/DungeonEnemies/hpBar.prefab
@@ -133,7 +133,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.98039216, g: 0.2509804, b: 0.25490198, a: 0.9019608}
+  m_Color: {r: 0.98039216, g: 0.2509804, b: 0.25490198, a: 0.7490196}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/CULLinary2/Assets/Prefabs/Loot/MoneyLoot.prefab
+++ b/CULLinary2/Assets/Prefabs/Loot/MoneyLoot.prefab
@@ -173,7 +173,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f74b17f762cd7a94d990d1424034210f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moneyAmount: 10
+  moneyAmount: 20
 --- !u!1 &7880053441415153288
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Prefabs/Spawnables/CactusShort.prefab
+++ b/CULLinary2/Assets/Prefabs/Spawnables/CactusShort.prefab
@@ -1,0 +1,123 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2531639283167531811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2531639283167531809}
+  - component: {fileID: 2531639283167531810}
+  - component: {fileID: 2531639283167531808}
+  m_Layer: 0
+  m_Name: CactusShort
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2531639283167531809
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2531639283167531811}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.049999997, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2641512907992491422}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &2531639283167531810
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2531639283167531811}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.3
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.3, z: 0}
+--- !u!114 &2531639283167531808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2531639283167531811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42bb38389d11ae84ca788fe96e9db00b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &2531639283630801525
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2531639283167531809}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_Name
+      value: cactus_short
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+--- !u!4 &2641512907992491422 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+  m_PrefabInstance: {fileID: 2531639283630801525}
+  m_PrefabAsset: {fileID: 0}

--- a/CULLinary2/Assets/Prefabs/Spawnables/CactusShort.prefab.meta
+++ b/CULLinary2/Assets/Prefabs/Spawnables/CactusShort.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c3012efb5747da4883dea6f9a95411f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Prefabs/Spawnables/CactusTall.prefab
+++ b/CULLinary2/Assets/Prefabs/Spawnables/CactusTall.prefab
@@ -1,0 +1,123 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7799821440097496844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7799821440097496847}
+  - component: {fileID: 7799821440097496846}
+  - component: {fileID: 7799821440097496845}
+  m_Layer: 0
+  m_Name: CactusTall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7799821440097496847
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7799821440097496844}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.049999997, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7760882187620699080}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &7799821440097496846
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7799821440097496844}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.3
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.3, z: 0}
+--- !u!114 &7799821440097496845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7799821440097496844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42bb38389d11ae84ca788fe96e9db00b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &7799821440734506019
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7799821440097496847}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_Name
+      value: cactus_tall
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+--- !u!4 &7760882187620699080 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+  m_PrefabInstance: {fileID: 7799821440734506019}
+  m_PrefabAsset: {fileID: 0}

--- a/CULLinary2/Assets/Prefabs/Spawnables/CactusTall.prefab.meta
+++ b/CULLinary2/Assets/Prefabs/Spawnables/CactusTall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ec0b0a9a69be924b84850c7ed00bfb7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Prefabs/UI/Buff UI Slot.prefab
+++ b/CULLinary2/Assets/Prefabs/UI/Buff UI Slot.prefab
@@ -222,6 +222,7 @@ GameObject:
   - component: {fileID: 8205982245067954640}
   - component: {fileID: 8205982245067954654}
   - component: {fileID: -2616016537821722016}
+  - component: {fileID: 6447853697994254408}
   m_Layer: 5
   m_Name: Buff UI Slot
   m_TagString: Untagged
@@ -330,7 +331,27 @@ MonoBehaviour:
   buffName: {fileID: 8205982245211412472}
   buffTimer: {fileID: 8205982244838221596}
   buffIcon: {fileID: 8205982244652779336}
-  buffBg: {fileID: 8205982245067954640}
+  flashAnim: {fileID: 6447853697994254408}
+  buffFlashTime: 6
+--- !u!95 &6447853697994254408
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8205982245067954642}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 24a4e3b818b1615408d06e204033e986, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &8205982245211412474
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -8918,63 +8918,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4943754348278179382, guid: 4180c73d6e91a2048826a68a1d901107, type: 3}
   m_PrefabInstance: {fileID: 147196159}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &304318294
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_RootOrder
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.049999997
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-      propertyPath: m_Name
-      value: cactus_short
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
 --- !u!1001 &305256836
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29156,7 +29099,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &998448002
 GameObject:
@@ -47675,63 +47618,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1605914823
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_RootOrder
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.049999997
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
-      propertyPath: m_Name
-      value: cactus_tall
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
 --- !u!1 &1607168232
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -2707,7 +2707,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &113357343
 MonoBehaviour:
@@ -10036,8 +10036,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &328406812
 MonoBehaviour:
@@ -18241,7 +18241,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &606350416
 MonoBehaviour:
@@ -25061,8 +25061,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &869518140
 MonoBehaviour:
@@ -26308,8 +26308,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &907285273
 MonoBehaviour:
@@ -28539,8 +28539,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &984280090
 MonoBehaviour:
@@ -33297,7 +33297,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1118671904
 MonoBehaviour:
@@ -34176,7 +34176,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1142679852
 MonoBehaviour:
@@ -37736,8 +37736,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1282498098
 MonoBehaviour:
@@ -38289,7 +38289,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1298023814
 MonoBehaviour:
@@ -48813,7 +48813,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 682, y: 480}
-  m_SizeDelta: {x: 104, y: 82}
+  m_SizeDelta: {x: 104, y: 60}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1640784775
 MonoBehaviour:
@@ -61867,8 +61867,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 12.5}
-  m_SizeDelta: {x: 0, y: -24.999998}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2087295828
 MonoBehaviour:

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -32985,6 +32985,10 @@ MonoBehaviour:
   recipesUnlockedText: {fileID: 323192952}
   monstersSeenText: {fileID: 1688282091}
   gameTimeText: {fileID: 1743430522}
+  warningPrefab: {fileID: 1085209639500972291, guid: 3e665808b292d594ba263a057e333c32, type: 3}
+  playerCanvas: {fileID: 2110931401}
+  playerCamera: {fileID: 1289944774}
+  player: {fileID: 1719325387}
 --- !u!4 &1111925686
 Transform:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -5967,6 +5967,42 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 209220708}
   m_CullTransparentMesh: 1
+--- !u!1 &212720176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 212720177}
+  m_Layer: 5
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &212720177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 212720176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6662030477055071423}
+  m_Father: {fileID: 6662030477062734893}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 80, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &213164705
 GameObject:
   m_ObjectHideFlags: 0
@@ -6212,8 +6248,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 307.5, y: -30}
-  m_SizeDelta: {x: 60, y: 60}
+  m_AnchoredPosition: {x: 340, y: -30}
+  m_SizeDelta: {x: 80, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &226667802
 GameObject:
@@ -8882,6 +8918,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4943754348278179382, guid: 4180c73d6e91a2048826a68a1d901107, type: 3}
   m_PrefabInstance: {fileID: 147196159}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &304318294
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.049999997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
+      propertyPath: m_Name
+      value: cactus_short
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
 --- !u!1001 &305256836
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29063,7 +29156,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &998448002
 GameObject:
@@ -38609,7 +38702,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 60, y: 60}
+  m_SizeDelta: {x: 80, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1311170272
 GameObject:
@@ -47582,6 +47675,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1605914823
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.049999997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+      propertyPath: m_Name
+      value: cactus_tall
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
 --- !u!1 &1607168232
 GameObject:
   m_ObjectHideFlags: 0
@@ -47910,7 +48060,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 60, y: 60}
+  m_SizeDelta: {x: 80, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1614373076
 GameObject:
@@ -92065,17 +92215,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6662030477055071420}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6662030478527420091}
   - {fileID: 6662030477077962415}
-  m_Father: {fileID: 6662030477062734893}
+  m_Father: {fileID: 212720177}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 60, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -92115,7 +92265,7 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 3
   m_Spacing: 20
-  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
@@ -92133,7 +92283,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 6662030477055071423}
+  - {fileID: 212720177}
   - {fileID: 1611221309}
   - {fileID: 1304680792}
   - {fileID: 218658839}

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -1403,6 +1403,7 @@ GameObject:
   m_Component:
   - component: {fileID: 71505059}
   - component: {fileID: 71505061}
+  - component: {fileID: 71505062}
   - component: {fileID: 71505060}
   m_Layer: 5
   m_Name: Image - RightSprite
@@ -1468,6 +1469,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 71505058}
   m_CullTransparentMesh: 1
+--- !u!95 &71505062
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71505058}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 15e718841f2880143b8cb5482f5efc9e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 2
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &71694334
 GameObject:
   m_ObjectHideFlags: 0
@@ -20080,6 +20100,7 @@ GameObject:
   - component: {fileID: 691199790}
   - component: {fileID: 691199792}
   - component: {fileID: 691199791}
+  - component: {fileID: 691199793}
   m_Layer: 5
   m_Name: Image - LeftSprite
   m_TagString: Untagged
@@ -20144,6 +20165,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 691199789}
   m_CullTransparentMesh: 1
+--- !u!95 &691199793
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 691199789}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 15e718841f2880143b8cb5482f5efc9e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 2
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &695611729
 GameObject:
   m_ObjectHideFlags: 0
@@ -39616,6 +39656,7 @@ GameObject:
   - component: {fileID: 1349204847}
   - component: {fileID: 1349204849}
   - component: {fileID: 1349204848}
+  - component: {fileID: 1349204850}
   m_Layer: 5
   m_Name: Image - Arrow
   m_TagString: Untagged
@@ -39680,6 +39721,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1349204846}
   m_CullTransparentMesh: 1
+--- !u!95 &1349204850
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1349204846}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 495df310d3373964ebd27936094ac18e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 2
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &1351689203
 GameObject:
   m_ObjectHideFlags: 0
@@ -46827,6 +46887,7 @@ GameObject:
   - component: {fileID: 1568170474}
   - component: {fileID: 1568170476}
   - component: {fileID: 1568170475}
+  - component: {fileID: 1568170477}
   m_Layer: 5
   m_Name: Image - Arrow
   m_TagString: Untagged
@@ -46891,6 +46952,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1568170473}
   m_CullTransparentMesh: 1
+--- !u!95 &1568170477
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568170473}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 495df310d3373964ebd27936094ac18e, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 2
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &1568950305
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Scenes/MainScene.unity
+++ b/CULLinary2/Assets/Scenes/MainScene.unity
@@ -85975,8 +85975,8 @@ MonoBehaviour:
   - name: Cacti
     isSpawnable: 1
     prefabs:
-    - {fileID: 919132149155446097, guid: 5dcefc10aeecd425f8b73579f64bcab5, type: 3}
-    - {fileID: 919132149155446097, guid: a764dbccd9bf2412aac9f1b4625d0367, type: 3}
+    - {fileID: 2531639283167531811, guid: 5c3012efb5747da4883dea6f9a95411f, type: 3}
+    - {fileID: 7799821440097496844, guid: 1ec0b0a9a69be924b84850c7ed00bfb7, type: 3}
     density: 50
     intersectRadius: 1
     removeCollider: 0

--- a/CULLinary2/Assets/Scenes/TutorialScene.unity
+++ b/CULLinary2/Assets/Scenes/TutorialScene.unity
@@ -3583,7 +3583,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 60, y: 60}
+  m_SizeDelta: {x: 80, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &87690316
 MonoBehaviour:
@@ -3642,10 +3642,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1330434415}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 2043715453}
+        m_TargetAssemblyTypeName: TutorialUIController, Assembly-CSharp
+        m_MethodName: ToggleInventory
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3653,18 +3653,6 @@ MonoBehaviour:
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 2122552286}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
         m_CallState: 2
 --- !u!1 &87975994
 GameObject:
@@ -7213,82 +7201,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 179286223}
   m_CullTransparentMesh: 1
---- !u!1 &189233090
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 189233091}
-  - component: {fileID: 189233093}
-  - component: {fileID: 189233092}
-  m_Layer: 5
-  m_Name: Image - Key BG
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &189233091
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 189233090}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 440366541}
-  m_Father: {fileID: 241937589}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -5, y: -5}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &189233092
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 189233090}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: de6311a2e44e6364aa9a46d89fb0ab55, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &189233093
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 189233090}
-  m_CullTransparentMesh: 1
 --- !u!1 &190168458
 GameObject:
   m_ObjectHideFlags: 0
@@ -8939,126 +8851,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 241354268}
   m_CullTransparentMesh: 1
---- !u!1 &241937588
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 241937589}
-  - component: {fileID: 241937591}
-  - component: {fileID: 241937590}
-  m_Layer: 5
-  m_Name: Button - Shop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &241937589
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 241937588}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1811274690}
-  - {fileID: 189233091}
-  m_Father: {fileID: 1101944567}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1800, y: -1080.1249}
-  m_SizeDelta: {x: 60, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &241937590
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 241937588}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fb59fab3258daa44883a6c50dfef71ec, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  doClickSound: 1
---- !u!114 &241937591
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 241937588}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1287172607}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
-      - m_Target: {fileID: 2122552286}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!1 &244241579
 GameObject:
   m_ObjectHideFlags: 0
@@ -17782,140 +17574,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 435775197}
-  m_CullTransparentMesh: 1
---- !u!1 &440366540
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 440366541}
-  - component: {fileID: 440366543}
-  - component: {fileID: 440366542}
-  m_Layer: 5
-  m_Name: Text (TMP) - Key
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &440366541
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 440366540}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 189233091}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &440366542
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 440366540}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: M
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: a1bc1abf93d37c348ab5a4e3cdfdd48c, type: 2}
-  m_sharedMaterial: {fileID: 5819034279512177362, guid: a1bc1abf93d37c348ab5a4e3cdfdd48c, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 15
-  m_fontSizeBase: 15
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &440366543
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 440366540}
   m_CullTransparentMesh: 1
 --- !u!1 &445083855
 GameObject:
@@ -32474,7 +32132,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 60, y: 60}
+  m_SizeDelta: {x: 80, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &921742845
 MonoBehaviour:
@@ -37613,7 +37271,6 @@ RectTransform:
   m_Children:
   - {fileID: 921742844}
   - {fileID: 87690315}
-  - {fileID: 241937589}
   m_Father: {fileID: 1895052347}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -37641,7 +37298,7 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 3
   m_Spacing: 20
-  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
@@ -42742,81 +42399,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1285894303}
   m_CullTransparentMesh: 1
---- !u!1 &1287172605
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1287172606}
-  - component: {fileID: 1287172608}
-  - component: {fileID: 1287172607}
-  m_Layer: 5
-  m_Name: Image - Icon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1287172606
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1287172605}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1811274690}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 50, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1287172607
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1287172605}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: d7796669cc7d711459f81d9eeaa8abf1, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1287172608
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1287172605}
-  m_CullTransparentMesh: 1
 --- !u!1 &1288859655
 GameObject:
   m_ObjectHideFlags: 0
@@ -46732,7 +46314,7 @@ MonoBehaviour:
   databaseLoader: {fileID: 2108735274}
   playerCharacter: {fileID: 5620305570932000160}
   uiCanvas: {fileID: 1094308043}
-  loadType: 0
+  loadType: 1
 --- !u!1 &1424650750
 GameObject:
   m_ObjectHideFlags: 0
@@ -58530,82 +58112,6 @@ MonoBehaviour:
   afterInventoryCount: </b> in inventory.
   ingredientsParentContainer: {fileID: 1333529122}
   recipeInfoDisplayIngredient: {fileID: 3118180260873789697, guid: 4a4429881da72d94ba1aacfc348806aa, type: 3}
---- !u!1 &1811274689
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1811274690}
-  - component: {fileID: 1811274692}
-  - component: {fileID: 1811274691}
-  m_Layer: 5
-  m_Name: Image - Icon BG
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1811274690
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811274689}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1287172606}
-  m_Father: {fileID: 241937589}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 60, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1811274691
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811274689}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e2c8f699d5acb034b979ea497c1b568e, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1811274692
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811274689}
-  m_CullTransparentMesh: 1
 --- !u!1 &1813937549
 GameObject:
   m_ObjectHideFlags: 0

--- a/CULLinary2/Assets/Scripts/Dialogue/DialogueDatabase.cs
+++ b/CULLinary2/Assets/Scripts/Dialogue/DialogueDatabase.cs
@@ -58,7 +58,7 @@ public static class DialogueDatabase
         /*   33 */ ("{[R]13}Wait! I have something to say, don't go yet!{[R]13}Today's message is brought to you by our sponsor, CornVPN!{[R]13}Protect your privacy from prying eyes with military-grade encryption!{[L]1}I'm never delivering food to this house again.{[R]13}Remember to like, comment and subscribe, and don't forget to hit the notification bell!{[L]1}Good day to you! I do hope that the food displeases your olfactory system!", 3),
         /*   34 */ ("{[R]14}Hey! I just wanted to say that I really appreciate your delivery service!{[L]0}You are welcome!", 5),
         /*   35 */ ("{[R]14}Wait, I have a promotional code!{[L]0}Sorry... Our delivery business does not have those!{[R]14}Oh? But I got an email that said I won a free pizza!{[R]14}I just had to put in my credit card details to get it!{[L]1}What! That sounds like a scam!{[R]14}Oh? By the love of holy potatoes!{[L]2}You'd better call the bank!{[R]14}I will! I'm such an idiot. Thanks for the food!", 5),
-        /*   36 */ ("{[L]1}What! You are a cactus!{[R]15}Yessa, that'sa right cha. Issa thar a problema?{[L]2}How is this possible?{[R]15}Howsa issa yousa possible?{[L]1}...{[L]1}Just give me my money and we'll never speak of this again!{[R]15}Right cha. Here yousa go cha.{[L]2}What was that?", 1),
+        /*   36 */ ("{[L]1}What! You are a cactus!{[R]15}Yessa, that'sa rite cha. Issa thar a problema?{[L]2}How is this possible?{[R]15}Howsa issa yousa possible?{[R]15}Yousa murderin movin froot talkin vegetablas!{[L]1}...{[L]1}Just give me my money and we'll never speak of this again...{[R]15}Rite cha. Here yousa go cha.{[L]2}That was strange!", 1),
     };
 
     private static string[] rawTutorialDialogues = {

--- a/CULLinary2/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/CULLinary2/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -60,6 +60,7 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
             if (UIController.instance != null)
             {
                 UIController.instance.isDialogueOpen = false;
+                UIController.instance.HandleUIActiveChange(false);
                 Time.timeScale = 1;
             }
             else
@@ -67,6 +68,7 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
                 if (TutorialUIController.instance != null)
                 {
                     TutorialUIController.instance.isDialogueOpen = false;
+                    TutorialUIController.instance.HandleUIActiveChange(false);
                     Time.timeScale = 1;
                 }
             }
@@ -95,6 +97,7 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
             if (UIController.instance != null)
             {
                 UIController.instance.isDialogueOpen = false;
+                UIController.instance.HandleUIActiveChange(false);
                 Time.timeScale = 1;
             }
             else
@@ -102,6 +105,7 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
                 if (TutorialUIController.instance != null)
                 {
                     TutorialUIController.instance.isDialogueOpen = false;
+                    TutorialUIController.instance.HandleUIActiveChange(false);
                     Time.timeScale = 1;
                 }
             }
@@ -270,12 +274,14 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
         if (UIController.instance != null)
         {
             UIController.instance.isDialogueOpen = true;
+            UIController.instance.HandleUIActiveChange(true);
         }
         else
         {
             if (TutorialUIController.instance != null)
             {
                 TutorialUIController.instance.isDialogueOpen = true;
+                TutorialUIController.instance.HandleUIActiveChange(true);
             }
         }
         Time.timeScale = 0;
@@ -286,6 +292,7 @@ public class DialogueManager : SingletonGeneric<DialogueManager>
     public void LoadAndRunTutorialDialogue(Dialogue dialogue)
     {
         TutorialUIController.instance.isDialogueOpen = true;
+        TutorialUIController.instance.HandleUIActiveChange(true);
         Time.timeScale = 0;
         LoadDialogue(dialogue);
         RunCurrentDialogue();

--- a/CULLinary2/Assets/Scripts/Dungeon/BuffSlot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/BuffSlot.cs
@@ -9,58 +9,44 @@ public class BuffSlot : MonoBehaviour
     [SerializeField] private TMP_Text buffName;
     [SerializeField] private TMP_Text buffTimer;
     [SerializeField] private Image buffIcon;
-    [SerializeField] private Image buffBg;
-    [SerializeField] private float buffFlashTime = 5f;
-    [SerializeField] private float buffFlashStep = 10f;
-    private int buffDuration;
+    [SerializeField] private Animator flashAnim;
+    [SerializeField] private float buffFlashTime = 6f;
+
+    private bool isBuffStarted = false;
+    private bool flashStarted = false;
+    private float buffDuration = 0.0f;
 
     public void SetupBuffSlot(Sprite icon, int duration, string name)
     {
         buffIcon.sprite = icon;
         buffName.text = name;
         buffDuration = duration;
-        StartCoroutine(StartBuff());
+        isBuffStarted = true;
     }
 
-    public string ConvertString(int duration)
+    public string ConvertString(float duration)
     {
         int minutes = Mathf.FloorToInt(duration / 60f);
-        int seconds = duration - minutes * 60;
+        int seconds = Mathf.FloorToInt(duration - minutes * 60);
         string parsedMinutes = minutes > 9 ? minutes.ToString() : "0" + minutes;
         string parsedSeconds = seconds > 9 ? seconds.ToString() : "0" + seconds;
         return parsedMinutes + ":" + parsedSeconds;
     }
 
-    public IEnumerator StartBuff()
+    private void Update()
     {
-        bool flashStarted = false;
-        while (buffDuration > 0)
+        if (isBuffStarted)
         {
             buffTimer.text = ConvertString(buffDuration);
-            buffDuration--;
-            yield return new WaitForSeconds(1f);
+            buffDuration -= Time.deltaTime;
+            if (buffDuration <= 0.0f)
+            {
+                Destroy(this.gameObject);
+            }
             if (buffDuration <= buffFlashTime && !flashStarted)
             {
+                flashAnim.SetTrigger("flashStarted");
                 flashStarted = true;
-                StartCoroutine(FlashBuff());
-            }
-        }
-        Destroy(this.gameObject);
-    }
-
-    public IEnumerator FlashBuff()
-    {
-        while (true)
-        {
-            for (float i = 175; i >= 0; i -= buffFlashStep)
-            {
-                buffBg.color = new Color(0, 0, 0, i / 255);
-                yield return null;
-            }
-            for (float j = 0; j <= 175; j += buffFlashStep)
-            {
-                buffBg.color = new Color(0, 0, 0, j / 255);
-                yield return null;
             }
         }
     }

--- a/CULLinary2/Assets/Scripts/Dungeon/Enemies/CactsusMonster.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Enemies/CactsusMonster.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CactsusMonster : Monster
+{
+    public override void HandleHit(float damage)
+    {
+        if (DialogueManager.instance)
+        {
+            string unparsed = "{[R]15}Owwww! Heysa!{[L]1}AAAAAAHHH!{[R]15}Watcha itsa!{[L]2}You're alive!{[R]15}That'sa did me " + damage.ToString("0") + " damage!{[L]2}I'm sorry!{[R]15}Me issa never orderin ahgain!";
+            Dialogue susDialogue = DialogueParser.Parse(unparsed);
+            DialogueManager.instance.LoadAndRun(susDialogue);
+        }
+    }
+}

--- a/CULLinary2/Assets/Scripts/Dungeon/Enemies/CactsusMonster.cs.meta
+++ b/CULLinary2/Assets/Scripts/Dungeon/Enemies/CactsusMonster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42bb38389d11ae84ca788fe96e9db00b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CULLinary2/Assets/Scripts/Dungeon/Enemies/EnemyAggressionManager.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Enemies/EnemyAggressionManager.cs
@@ -28,8 +28,12 @@ public class EnemyAggressionManager : MonoBehaviour
     public void Add(int i)
     {
         aggressiveEnemies += i;
+        if (aggressiveEnemies < 0)
+        {
+            aggressiveEnemies = 0;
+        }
 
-        if (aggro && aggressiveEnemies <= 0)
+        if (aggro && aggressiveEnemies == 0)
         {
             aggro = false;
             BGM.Instance.SetTrack(0);
@@ -39,5 +43,12 @@ public class EnemyAggressionManager : MonoBehaviour
             aggro = true;
             BGM.Instance.SetTrack(1);
         }
+    }
+
+    public void Reset()
+    {
+        aggressiveEnemies = 0;
+        aggro = false;
+        BGM.Instance.SetTrack(0);
     }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/Enemies/MonsterScript.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Enemies/MonsterScript.cs
@@ -127,18 +127,7 @@ public class MonsterScript : Monster
     {
         SetupHpBar();
         SetupFlash();
-
-        foreach (GameObject ui in uiElements)
-        {
-            if (ui != null)
-            {
-                ui.SetActive(false);
-            }
-            else
-            {
-                uiElements.Remove(null);
-            }
-        }
+        RemoveUiElements();
     }
 
     private void Update()
@@ -194,7 +183,6 @@ public class MonsterScript : Monster
                 {
                     EnemyAggressionManager.Instance.Add(1);
                 }
-
                 foreach (GameObject ui in uiElements)
                 {
                     if (ui != null)
@@ -206,6 +194,10 @@ public class MonsterScript : Monster
                         uiElements.Remove(null);
                     }
                 }
+            }
+            else if (CheckIfPlayerGoingToMoveAway())
+            {
+                RemoveUiElements();
             }
 
             Vector2 screenPos = playerCamera.WorldToScreenPoint(transform.position);
@@ -243,18 +235,7 @@ public class MonsterScript : Monster
 			{
                 EnemyAggressionManager.Instance.Add(-1);
             }
-
-            foreach (GameObject ui in uiElements)
-            {
-                if (ui != null)
-                {
-                    ui.SetActive(false);
-                }
-                else
-                {
-                    uiElements.Remove(null);
-                }
-            }
+            RemoveUiElements();
         }
     }
 
@@ -262,20 +243,8 @@ public class MonsterScript : Monster
     {
         wasAggressive = false;
         EnemyAggressionManager.Instance.Add(-1);
-
-        foreach (GameObject ui in uiElements)
-        {
-            if (ui != null)
-            {
-                ui.SetActive(false);
-            }
-            else
-            {
-                uiElements.Remove(null);
-            }
-        }
+        RemoveUiElements();
     }
-
 
     public bool checkIfDead()
     {
@@ -297,6 +266,28 @@ public class MonsterScript : Monster
     public void SetStateMachine(MonsterState newState)
     {
         currentState = newState;
+    }
+
+    // Checks if the player is going to be teleported away in a moment
+    private bool CheckIfPlayerGoingToMoveAway()
+    {
+        return PlayerHealth.instance.WasDeathCalled() ||
+            (GameTimer.instance != null && GameTimer.instance.WasEndOfDayCalled());
+    }
+
+    private void RemoveUiElements()
+    {
+        foreach (GameObject ui in uiElements)
+        {
+            if (ui != null)
+            {
+                ui.SetActive(false);
+            }
+            else
+            {
+                uiElements.Remove(null);
+            }
+        }
     }
 
     private void SetupHpBar()

--- a/CULLinary2/Assets/Scripts/Dungeon/Enemies/TomatoAttack.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Enemies/TomatoAttack.cs
@@ -35,6 +35,7 @@ public class TomatoAttack : MonsterAttack
         Instantiate(prefabForExplosion, positionToInstantiate, Quaternion.identity);
         positionToInstantiate = FindPositionInRadiusAround(270f, 360f);
         Instantiate(prefabForExplosion, positionToInstantiate, Quaternion.identity);
+        EnemyAggressionManager.Instance.Add(-1);
     }      
 
     private Vector3 FindPositionInRadiusAround(float startDegree, float endDegree)

--- a/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
@@ -94,12 +94,12 @@ public class GameTimer : SingletonGeneric<GameTimer>
 
     private void Update()
     {
-        // For debug
-        if (Input.GetKeyDown(KeyCode.E))
-        {
-            ShowEndOfDayMenu();
-            return;
-        }
+        // // For debug
+        // if (Input.GetKeyDown(KeyCode.E))
+        // {
+        //     ShowEndOfDayMenu();
+        //     return;
+        // }
 
         if (Preset == null || !isRunning)
             return;

--- a/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
@@ -44,6 +44,7 @@ public class GameTimer : SingletonGeneric<GameTimer>
 
     private bool isNewDay = true; // prevent OnStartNewDay from being invoked multiple times
     private bool isRunning = false;
+    private bool isEndOfDay = false;
 
     private NewspaperDetails newspaperDets;
 
@@ -78,9 +79,12 @@ public class GameTimer : SingletonGeneric<GameTimer>
         DayText.text = "DAY " + dayNum;
         UpdateTimedObjects();
 
-        // enable unlocked monsters
         OnStartNewDay += () =>
         {
+            // Reset isEndOfDay flag
+            isEndOfDay = false;
+
+            // enable unlocked monsters
             foreach (MonsterName mn in PlayerManager.instance.unlockedMonsters)
             {
                 EcosystemManager.EnablePopulation(mn);
@@ -90,6 +94,13 @@ public class GameTimer : SingletonGeneric<GameTimer>
 
     private void Update()
     {
+        // For debug
+        if (Input.GetKeyDown(KeyCode.E))
+        {
+            ShowEndOfDayMenu();
+            return;
+        }
+
         if (Preset == null || !isRunning)
             return;
 
@@ -248,6 +259,9 @@ public class GameTimer : SingletonGeneric<GameTimer>
     private void ShowEndOfDayMenu()
     {
         Time.timeScale = 0;
+        isEndOfDay = true;
+        // Reset BGM
+        EnemyAggressionManager.Instance.Reset();
         UIController.instance.ShowEndOfDayMenu();
         // Increment newspaper for next day
         NewsIssue currentNews = DatabaseLoader.GetOrderedNewsIssueById(currentIssueNumber + 1);
@@ -259,6 +273,11 @@ public class GameTimer : SingletonGeneric<GameTimer>
         }
         //Restore health here
         GoToNextDay();
+    }
+
+    public bool WasEndOfDayCalled()
+    {
+        return isEndOfDay;
     }
 
     public void PlayBossMusic()

--- a/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/GameTimer.cs
@@ -189,6 +189,7 @@ public class GameTimer : SingletonGeneric<GameTimer>
                 Time.timeScale = 0;
                 newspaperDets.UpdateNewspaperIssueUI(currentNews);
                 UIController.instance.isNewspaperOpen = true;
+                UIController.instance.HandleUIActiveChange(true);
                 newspaper.SetActive(true);
                 hudToHide.SetActive(false);
                 // when newspaper is closed, CloseNewspaperAndStartDay is called

--- a/CULLinary2/Assets/Scripts/Dungeon/Inventory/ItemLoot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Inventory/ItemLoot.cs
@@ -7,7 +7,7 @@ public class ItemLoot : Loot
 {
     [SerializeField] private InventoryItem itemLoot;
 
-    protected override void OnPickup(PlayerPickup playerPickup)
+    protected override bool OnPickup(PlayerPickup playerPickup)
     {
         if (InventoryManager.instance != null)
         {
@@ -17,6 +17,12 @@ public class ItemLoot : Loot
 
                 LootManager.instance.removeLoot(this.gameObject);
                 Destroy(gameObject);
+                return true;
+            }
+            else
+            {
+                InventoryManager.instance.DisplayWarning("Inventory full!");
+                return false;
             }
         }
         else if (TutorialInventoryManager.instance != null)
@@ -27,7 +33,13 @@ public class ItemLoot : Loot
 
                 LootManager.instance.removeLoot(this.gameObject);
                 Destroy(gameObject);
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
+        return false;
     }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/Inventory/Loot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Inventory/Loot.cs
@@ -6,7 +6,9 @@ public abstract class Loot : MonoBehaviour
 {
     private Rigidbody rb;
 
+    public float delayTimeBetweenPickupTries = 1.0f;
     bool lootable = false;
+    float delay = 0.0f;
 
     void Start()
     {
@@ -14,6 +16,15 @@ public abstract class Loot : MonoBehaviour
         rb = GetComponent<Rigidbody>();
         rb.AddForce(Vector3.up * 20, ForceMode.Impulse);
         StartCoroutine(spawningCooldown());
+    }
+
+    void Update()
+    {
+        if (delay > 0.0f)
+        {
+            delay -= Time.deltaTime;
+            delay = Mathf.Max(delay, 0.0f);
+        }
     }
 
     IEnumerator spawningCooldown()
@@ -24,17 +35,20 @@ public abstract class Loot : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (!lootable) return;
+        if (!lootable || delay > 0.0f) return;
 
         PlayerPickup playerPickup = other.GetComponent<PlayerPickup>();
         if (playerPickup != null)
         {
-            OnPickup(playerPickup);
+            if (!OnPickup(playerPickup))
+            {
+                delay = delayTimeBetweenPickupTries;
+            }
         }
     }
 
-    protected virtual void OnPickup(PlayerPickup playerPickup)
+    protected virtual bool OnPickup(PlayerPickup playerPickup)
     {
-
+        return false;
     }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/Inventory/MoneyLoot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Inventory/MoneyLoot.cs
@@ -6,7 +6,7 @@ public class MoneyLoot : Loot
 {
     [SerializeField] private int moneyAmount;
 
-    protected override void OnPickup(PlayerPickup playerPickup)
+    protected override bool OnPickup(PlayerPickup playerPickup)
     {
         PlayerManager.instance.currentMoney += moneyAmount;
         OrdersManager.AddToMoneyEarnedToday(moneyAmount);
@@ -14,5 +14,6 @@ public class MoneyLoot : Loot
 
         LootManager.instance.removeLoot(this.gameObject);
         Destroy(gameObject);
+        return true;
     }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/Inventory/MoneyLoot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Inventory/MoneyLoot.cs
@@ -8,9 +8,14 @@ public class MoneyLoot : Loot
 
     protected override bool OnPickup(PlayerPickup playerPickup)
     {
-        PlayerManager.instance.currentMoney += moneyAmount;
-        OrdersManager.AddToMoneyEarnedToday(moneyAmount);
-        playerPickup.PickUpMoney(moneyAmount);
+        int moneyAmountReal = moneyAmount;
+        if (OrdersManager.instance != null && OrdersManager.instance.AreEarningsDoubled())
+        {
+            moneyAmountReal *= 2;
+        }
+        PlayerManager.instance.currentMoney += moneyAmountReal;
+        OrdersManager.AddToMoneyEarnedToday(moneyAmountReal);
+        playerPickup.PickUpMoney(moneyAmountReal);
 
         LootManager.instance.removeLoot(this.gameObject);
         Destroy(gameObject);

--- a/CULLinary2/Assets/Scripts/Dungeon/Inventory/PotionLoot.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Inventory/PotionLoot.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PotionLoot : Loot
 {
-    protected override void OnPickup(PlayerPickup playerPickup)
+    protected override bool OnPickup(PlayerPickup playerPickup)
     {
         int randomPotion = Random.Range(1, 6);
         bool isFull = false;
@@ -70,10 +70,11 @@ public class PotionLoot : Loot
         }
         if (isFull)
         {
-            return;
+            return false;
         }
         playerPickup.PickUpPotion(randomPotion);
         LootManager.instance.removeLoot(this.gameObject);
         Destroy(gameObject);
+        return true;
     }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/Orders/OrdersManager.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/Orders/OrdersManager.cs
@@ -285,6 +285,12 @@ public class OrdersManager : SingletonGeneric<OrdersManager>
         return firstGeneration;
     }
 
+    // Checks if earnings are doubled
+    public bool AreEarningsDoubled()
+    {
+        return isDoubled;
+    }
+
     // Gets a dictionary of recipe IDs mapped to the number
     // of orders that the player has currently for that recipe.
     public Dictionary<int, int> GetNumberOfOrdersByRecipe()

--- a/CULLinary2/Assets/Scripts/Dungeon/SingletonGeneric.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/SingletonGeneric.cs
@@ -34,4 +34,9 @@ public class SingletonGeneric<T> : MonoBehaviour where T : SingletonGeneric<T>
             Destroy(gameObject);
         }
     }
+
+    public static bool CheckIfInstanceExists()
+    {
+        return instance != null;
+    }
 }

--- a/CULLinary2/Assets/Scripts/Dungeon/SpherePlayerCollider.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/SpherePlayerCollider.cs
@@ -58,7 +58,10 @@ public class SpherePlayerCollider : MonoBehaviour
     public void DoExit()
     {
         playerWithinRange = false;
-        popUpPrompts?.SetActive(false);
+        if (popUpPrompts != null)
+        {
+            popUpPrompts.SetActive(false);
+        }
         parentInteractable.OnPlayerLeave();
         if (UIController.instance != null)
         {

--- a/CULLinary2/Assets/Scripts/Dungeon/SpherePlayerCollider.cs
+++ b/CULLinary2/Assets/Scripts/Dungeon/SpherePlayerCollider.cs
@@ -58,7 +58,7 @@ public class SpherePlayerCollider : MonoBehaviour
     public void DoExit()
     {
         playerWithinRange = false;
-        popUpPrompts.SetActive(false);
+        popUpPrompts?.SetActive(false);
         parentInteractable.OnPlayerLeave();
         if (UIController.instance != null)
         {

--- a/CULLinary2/Assets/Scripts/Player/InventoryManager.cs
+++ b/CULLinary2/Assets/Scripts/Player/InventoryManager.cs
@@ -36,6 +36,12 @@ public class InventoryManager : SingletonGeneric<InventoryManager>
     [SerializeField] private TMP_Text recipesUnlockedText;
     [SerializeField] private TMP_Text monstersSeenText;
     [SerializeField] private TMP_Text gameTimeText;
+    [Header("Inventory Full Warning")]
+    [SerializeField] private GameObject warningPrefab;
+    [SerializeField] private GameObject playerCanvas;
+    [SerializeField] private Camera playerCamera;
+    [SerializeField] private GameObject player;
+    
     private InventorySlot[] slots;
     private int inventoryLimit = 20;
 
@@ -325,5 +331,14 @@ public class InventoryManager : SingletonGeneric<InventoryManager>
             }
         }
         return cookableRecipes;
+    }
+
+    // Displays a warning to the UI
+    public void DisplayWarning(string message)
+    {
+        GameObject warning = Instantiate(warningPrefab);
+        warning.transform.GetComponentInChildren<Text>().text = message.ToString();
+        warning.transform.SetParent(playerCanvas.transform);
+        warning.transform.position = playerCamera.WorldToScreenPoint(player.transform.position);
     }
 }

--- a/CULLinary2/Assets/Scripts/Tutorial/TutorialUIController.cs
+++ b/CULLinary2/Assets/Scripts/Tutorial/TutorialUIController.cs
@@ -503,7 +503,7 @@ public class TutorialUIController : SingletonGeneric<TutorialUIController>
         }
     }
 
-    private void HandleUIActiveChange(bool active)
+    public void HandleUIActiveChange(bool active)
     {
         BGM.Instance.SetVolume(active ? 0.15f : 0.3f);
     }

--- a/CULLinary2/Assets/Scripts/UI/UIController.cs
+++ b/CULLinary2/Assets/Scripts/UI/UIController.cs
@@ -147,6 +147,8 @@ public class UIController : SingletonGeneric<UIController>
         {
             player.GetComponent<CharacterController>().enabled = false;
             deathMenuActive = true;
+            // Reset BGM
+            EnemyAggressionManager.Instance.Reset();
             //isPaused = true;
             StartCoroutine(PauseToShowDeathAnimation());
         }

--- a/CULLinary2/Assets/Scripts/UI/UIController.cs
+++ b/CULLinary2/Assets/Scripts/UI/UIController.cs
@@ -145,6 +145,7 @@ public class UIController : SingletonGeneric<UIController>
     {
         if (!playerDeathMenu.activeSelf && !deathMenuActive)
         {
+            HandleUIActiveChange(true);
             player.GetComponent<CharacterController>().enabled = false;
             deathMenuActive = true;
             // Reset BGM
@@ -193,6 +194,7 @@ public class UIController : SingletonGeneric<UIController>
         if (endOfDayMenu)
         {
             //isPaused = true;
+            HandleUIActiveChange(true);
             endOfDayMenu.SetActive(true);
             EndOfDayPanelStatistics stats = endOfDayMenu.GetComponent<EndOfDayPanelStatistics>();
             stats.UpdateStatistics(GameTimer.GetDayNumber(),
@@ -488,6 +490,7 @@ public class UIController : SingletonGeneric<UIController>
                 if (DialogueManager.instance.CheckIfIsFirstDialogue())
                 {
                     DialogueManager.instance.CloseAllDialogue();
+                    UIController.instance.HandleUIActiveChange(false);
                     Time.timeScale = 1.0f;
                     isDialogueOpen = false;
                 }
@@ -575,7 +578,7 @@ public class UIController : SingletonGeneric<UIController>
         }
     }
 
-    private void HandleUIActiveChange(bool active)
+    public void HandleUIActiveChange(bool active)
     {
         BGM.Instance.SetVolume(active ? 0.15f : 0.3f);
     }

--- a/CULLinary2/Assets/Scripts/Util/Cullable.cs
+++ b/CULLinary2/Assets/Scripts/Util/Cullable.cs
@@ -11,6 +11,9 @@ public class Cullable : MonoBehaviour
 
     void OnDestroy()
     {
-        ObjectCuller.Instance.Remove(this.gameObject);
+        if (ObjectCuller.CheckIfInstanceExists())
+        {
+            ObjectCuller.Instance.Remove(this.gameObject);
+        }
     }
 }


### PR DESCRIPTION
### UI tweaks
* Add bobbing animation to dialogue for arrow and characters
* Add an inventory full warning when trying to pick up too much items
* Align Rest and Close text in UI menus
* Make HP bars slightly more translucent
* Align top-right UI elements to the left in TutorialScene
* Fix shifting of top-right UI icons when truck is added

### UI fixes
* Hide enemy health bars when player dies or end of day
* Fix buff UI counter stopping when opening menus

### BGM fixes
* Fix hype BGM continuing after death or end of day
* Fix tomato causing hype BGM to play after exploding itself
* Lower BGM in dialogue, death, end of day menus 

### Balance
* Buff chests a little (10 per coin to 20 per coin)
* Double Earnings buff will now affect money earned from chests

### Editor Fixes
* Fix ObjectCuller not cleaned up on exit
* Fix SpherePlayerCollider trying to access non-existent object

### Other
* Easter egg with cactsus

